### PR TITLE
#102 QA empty .cncfci.yml for Envoy

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
-  display_name: Envoyv2
-  sub_title: Service Mesh Test
-  project_url: "https://github.com/envoyproxy/envoy/releases"
+  logo_url: 
+  display_name: 
+  sub_title: 
+  project_url: 


### PR DESCRIPTION
Testing new .cncfci.yml for project details
- removed logo url, display name, subtitle, project url
- expected behavior - user can see the Project Name, Logo and Sub Title with the content from the [cross-cloud.yml](https://github.com/crosscloudci/cncf-configuration/blob/master/cross-cloud.yml) file