### PR TITLE
#102 QA Envoy config on staging

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:	
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"	
-  display_name: Envoy2	
-  sub_title: Service Mesh2
-  project_url: "https://github.com/envoyproxy/envoy/releases"
+  display_name: Envoy
+  sub_title: Service Mesh
+  project_url: "https://github.com/envoyproxy/envoy"


### PR DESCRIPTION
https://github.com/crosscloudci/crosscloudci/issues/102
- Remove QA details, add real project details

  display_name: Envoy
  sub_title: Service Mesh
  project_url: "https://github.com/envoyproxy/envoy"