### PR TITLE
#77 replace png with svg logo

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:	
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"	
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/envoy/icon/color/envoy-icon-color.svg?sanitize=true"	
   display_name: Envoy
   sub_title: Service Mesh
   project_url: "https://github.com/envoyproxy/envoy"


### PR DESCRIPTION
https://github.com/crosscloudci/ci-dashboard/issues/77

Changes made: 
  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/envoy/icon/color/envoy-icon-color.svg?sanitize=true"