### PR TITLE
Add support for separate environments for status results - K8s drop-down selection 

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,0 +1,5 @@
+project:
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
+  display_name: Envoy
+  sub_title: Service Mesh
+  project_url: "https://github.com/envoyproxy/envoy"


### PR DESCRIPTION
This request is needed for https://github.com/crosscloudci/ci_status_repository/pull/18