### PR TITLE
update logo w/ project directory URL

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:	
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/envoy/icon/color/envoy-icon-color.svg?sanitize=true"	
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/envoy/icon/color/envoy-icon-color.svg?sanitize=true"	
   display_name: Envoy
   sub_title: Service Mesh
   project_url: "https://github.com/envoyproxy/envoy"


### PR DESCRIPTION
crosscloudci/ci-dashboard#90

Changes made: add /projects/ to URL

logo_url: 
https://raw.githubusercontent.com/cncf/artwork/master/projects/envoy/icon/color/envoy-icon-color.svg