### PR TITLE
Add stable_ref and head_ref to integration

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -5,4 +5,6 @@ project:
   project_url: "https://github.com/envoyproxy/envoy"
   arch:
     - "amd64"
-    - "arm64"   
+    - "arm64"
+  stable_ref: "v1.10.0"
+  head_ref: "master"


### PR DESCRIPTION
Add stable_ref and head_ref to integration
- https://github.com/crosscloudci/crosscloudci/issues/103
- works as expected on prod, update integration branch
