### PR TITLE
enable Envoy v1.11.1 on cidev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -6,5 +6,5 @@ project:
   arch:
     - "amd64"
     - "arm64"
-  stable_ref: "v1.10.0"
+  stable_ref: "v1.11.1"
   head_ref: "master"


### PR DESCRIPTION
- enable Envoy v1.11.1
- released Aug 13, 2019