### PR TITLE
update caption to Network Proxy

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,7 +1,7 @@
 project:	
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/envoy/icon/color/envoy-icon-color.svg?sanitize=true"	
   display_name: Envoy
-  sub_title: Service Mesh
+  sub_title: Network Proxy
   project_url: "https://github.com/envoyproxy/envoy"
   arch:
     - "amd64"


### PR DESCRIPTION
Resolves the problem: 
- the caption for Envoy on https://www.cncf.io/projects/ says "Network Proxy"