### PR TITLE
Enable v1.14.2 on staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,15 +63,15 @@ compile-arm:
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
     - popd 
-    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
     expire_in: 5 weeks
     paths:
-      - ./build_release_stripped/envoy
       - ./build_release/envoy
+      - ./build_release_stripped/envoy
 
 compile:
   image: "crosscloudci/debian-docker:latest"
@@ -85,15 +85,15 @@ compile:
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
     - popd 
-    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
     expire_in: 5 weeks
     paths:
-     - ./build_release_stripped/envoy
      - ./build_release/envoy
+     - ./build_release_stripped/envoy
 
 container-arm:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ compile-arm:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
-    - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
+    - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
     - popd 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
@@ -83,7 +83,7 @@ compile:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
-    - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
+    - ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
     - popd 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,7 +1,7 @@
 project:	
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/envoy/icon/color/envoy-icon-color.svg?sanitize=true"	
   display_name: Envoy
-  sub_title: Service Mesh
+  sub_title: Network Proxy
   project_url: "https://github.com/envoyproxy/envoy"
   arch:
     - "amd64"


### PR DESCRIPTION
Build passed as expected - https://gitlab.dev.cncf.ci/envoyproxy/envoy/-/jobs/200304

## Description

- v1.14.2 was released on 06/08/2020
- update stable on staging

## Issues:

https://github.com/vulk/cncf_ci/issues/72

How Has This Been Tested?
---
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested with trigger client against
  - [ ]  cidev.cncf.ci
  - [ ]  dev.cncf.ci
  - [ ]  staging.cncf.ci
  - [ ]  cncf.ci (production)
- [ ] Browser tested on staging.cncf.ci
- [x] Manually tested on https://gitlab.dev.cncf.ci web ui - Build Succeeded
- [ ] Have not tested

Types of changes:
---
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Version update

Checklist:
---
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required