### PR TITLE
Envoy stable v1.14.2 from staging to production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,8 @@ before_script:
     fi
 
 baseimage-aufs:
-  tags: aufs
+  tags:
+    - aufs
   image: crosscloudci/debian-docker
   stage: dependencies
   variables:
@@ -49,7 +50,8 @@ baseimage-aufs:
 baseimage-overlayfs:
   image: crosscloudci/debian-docker
   stage: dependencies
-  tags: overlayfs
+  tags:
+    - overlayfs
   variables:
     LINUX_DISTRO: ubuntu
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ baseimage-aufs:
         docker push "$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO:$CI_COMMIT_REF_SLUG"
       else
         echo "This is stable, skip aufs build"
-        exit 1
+        exit 0
       fi
 
 baseimage-overlayfs:
@@ -60,7 +60,7 @@ baseimage-overlayfs:
     - >
       if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
         echo "This is master, skip overlayfs build"
-        exit 1
+        exit 0
       else
         sed -i 's/16.04.10/16.04.11/g' ./build_container_ubuntu.sh
         CIRCLE_SHA1="$CI_COMMIT_REF_SLUG" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO" ./docker_build.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,9 +22,9 @@ before_script:
     fi
   - >
     if [ "$CI_JOB_NAME" == "compile" ]; then
-      source /opt/local/ubuntu/etc/rvmrc ; source /opt/local/ubuntu/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+      source /opt/local/ubuntu/etc/rvmrc ; source /opt/local/ubuntu/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
     else
-      source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+      source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
     fi
 
 baseimage:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ container-arm:
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine-debug
-    - sed -i "1s|.*|FROM arm64v8/ubuntu:16.04|" ./ci/Dockerfile-envoy-image
+    - sed -i "1s|.*|FROM arm64v8/ubuntu:18.04|" ./ci/Dockerfile-envoy-image
     - docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .
@@ -137,6 +137,7 @@ container:
   script:
     - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.amd64
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+    - sed -i "1s|.*|FROM ubuntu:18.04|" ./ci/Dockerfile-envoy-image
     - docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,8 +52,6 @@ baseimage-arm:
 
     
 baseimage:
-  tags:
-    - aufs
   image: crosscloudci/debian-docker:latest
   stage: dependencies
   only:
@@ -86,8 +84,6 @@ compile-arm:
       - ./build_release_stripped/envoy
 
 compile:
-  tags:
-    - aufs
   image: "$CI_REGISTRY_IMAGE/envoy-build-ubuntu:$CI_COMMIT_REF_SLUG"
   stage: build
   only:
@@ -133,8 +129,6 @@ container-arm:
       - release.env
 
 container:
-  tags:
-    - aufs
   image: crosscloudci/debian-docker:latest
   stage: package
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,7 +137,6 @@ container:
   script:
     - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.amd64
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-    - sed -i "1s|.*|FROM ubuntu:19.04|" ./ci/Dockerfile-envoy-image
     - docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ container-arm:
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine-debug
-    - sed -i "1s|.*|FROM arm64v8/ubuntu:18.04|" ./ci/Dockerfile-envoy-image
+    - sed -i "1s|.*|FROM arm64v8/ubuntu:19.04|" ./ci/Dockerfile-envoy-image
     - docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .
@@ -137,7 +137,7 @@ container:
   script:
     - IMAGE_TAG=${CI_COMMIT_REF_NAME}.${CI_COMMIT_SHA_SHORT}.${CI_JOB_ID}.amd64
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-    - sed -i "1s|.*|FROM ubuntu:18.04|" ./ci/Dockerfile-envoy-image
+    - sed -i "1s|.*|FROM ubuntu:19.04|" ./ci/Dockerfile-envoy-image
     - docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,9 +39,8 @@ baseimage:
       if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
         echo "Skip g++ update"
       else
-        sed -i 's/16.04.9/16.04.10/g' ./build_container_ubuntu.sh
+        sed -i 's/16.04.10/16.04.11/g' ./build_container_ubuntu.sh
       fi
-    - sleep 100000
     - CIRCLE_SHA1="$CI_COMMIT_REF_SLUG" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO" ./docker_build.sh
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker push "$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO:$CI_COMMIT_REF_SLUG"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ baseimage:
       else
         sed -i 's/16.04.9/16.04.10/g' ./build_container_ubuntu.sh
       fi
+    - sleep 100000
     - CIRCLE_SHA1="$CI_COMMIT_REF_SLUG" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO" ./docker_build.sh
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker push "$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO:$CI_COMMIT_REF_SLUG"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ before_script:
     fi
   - >
     if [ "$CI_JOB_NAME" == "compile" ]; then
-      source /opt/local/ubuntu/etc/rvmrc ; source /opt/local/ubuntu/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+      source /opt/local/ubuntu/etc/rvmrc ; source /opt/local/ubuntu/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; chmod +x ./bin/update_dashboard ; ./bin/update_dashboard ; popd
     else
       source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; chmod +x ./bin/update_dashboard ; ./bin/update_dashboard ; popd
     fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ before_script:
     if [ "$CI_JOB_NAME" == "compile" ]; then
       source /opt/local/ubuntu/etc/rvmrc ; source /opt/local/ubuntu/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
     else
-      source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; ./bin/update_dashboard ; popd
+      source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; chmod +x ./bin/update_dashboard ; ./bin/update_dashboard ; popd
     fi
 
 baseimage:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,8 @@ before_script:
       source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; chmod +x ./bin/update_dashboard ; ./bin/update_dashboard ; popd
     fi
 
-baseimage:
+baseimage-aufs:
+  tags: aufs
   image: crosscloudci/debian-docker
   stage: dependencies
   variables:
@@ -37,14 +38,33 @@ baseimage:
     - sed -i "1s|.*|FROM crosscloudci/ubuntu-xenial|" ./Dockerfile-ubuntu
     - >
       if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
-        echo "Skip g++ update"
+        CIRCLE_SHA1="$CI_COMMIT_REF_SLUG" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO" ./docker_build.sh
+        docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+        docker push "$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO:$CI_COMMIT_REF_SLUG"
+      else
+        echo "This is stable, skip aufs build"
+        exit 1
+      fi
+
+baseimage-overlayfs:
+  image: crosscloudci/debian-docker
+  stage: dependencies
+  tags: overlayfs
+  variables:
+    LINUX_DISTRO: ubuntu
+  script:
+    - cd ./ci/build_container/
+    - sed -i "1s|.*|FROM crosscloudci/ubuntu-xenial|" ./Dockerfile-ubuntu
+    - >
+      if [ "$CI_COMMIT_REF_NAME" == "master" ]; then
+        echo "This is master, skip overlayfs build"
+        exit 1
       else
         sed -i 's/16.04.10/16.04.11/g' ./build_container_ubuntu.sh
+        CIRCLE_SHA1="$CI_COMMIT_REF_SLUG" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO" ./docker_build.sh
+        docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+        docker push "$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO:$CI_COMMIT_REF_SLUG"
       fi
-    - CIRCLE_SHA1="$CI_COMMIT_REF_SLUG" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO" ./docker_build.sh
-    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
-    - docker push "$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO:$CI_COMMIT_REF_SLUG"
-
 
 compile:
   image: "$CI_REGISTRY_IMAGE/envoy-build-$LINUX_DISTRO:$CI_COMMIT_REF_SLUG"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,8 @@
 project:	
-  logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"	
-  display_name: Envoy	
-  sub_title: Service Mesh	
+  logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/envoy/icon/color/envoy-icon-color.svg?sanitize=true"	
+  display_name: Envoy
+  sub_title: Service Mesh
   project_url: "https://github.com/envoyproxy/envoy"
+  arch:
+    - "amd64"
+    - "arm64"   


### PR DESCRIPTION
## Description
  - v1.14.2 was released on 06-08-2020
  - update stable on staging
  - envoy v1.14.2 docker build changed it's ci/Dockerfile-envoy-image to ci/Dockerfile-envoy; Added logic in the amd64 build steps to handle both filenames

## Issues:

https://github.com/vulk/cncf_ci/issues/70
https://github.com/crosscloudci/envoy-configuration/pull/38

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [x]  Browser tested on staging.cncf.ci
 - [ ]  Have not tested

## Types of changes:
 - [x]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
