### PR TITLE
V1.16.0+ fixes for envoy stable release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,7 +140,7 @@ container:
          docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
       fi
     #- sleep 3600
-    - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
+    #- docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     #- docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
     - echo export IMAGE_ARGS=\"--set image.repository=$CI_REGISTRY_IMAGE\" | tee release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,11 +83,10 @@ compile:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
-    - sleep 3600
     - ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
     - popd 
-    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
-    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/linux/$ARCH/build_release/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/linux/$ARCH/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,9 +139,7 @@ container:
       else
          docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
       fi
-    #- sleep 3600
     #- docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
-    #- docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
     - echo export IMAGE_ARGS=\"--set image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
     - echo export TAG_ARGS=\"--set image.tag=$IMAGE_TAG\" | tee -a release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,9 +139,9 @@ container:
       else
          docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
       fi
-    - sleep 3600
+    #- sleep 3600
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
-    - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .
+    #- docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"
     - echo export IMAGE_ARGS=\"--set image.repository=$CI_REGISTRY_IMAGE\" | tee release.env
     - echo export TAG_ARGS=\"--set image.tag=$IMAGE_TAG\" | tee -a release.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,6 +139,7 @@ container:
       else
          docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
       fi
+    - sleep 3600
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .
     - docker push "$CI_REGISTRY_IMAGE:$IMAGE_TAG"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,7 @@ compile:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
+    - sleep 3600
     - ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
     - popd 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 


### PR DESCRIPTION
**Description**
envoy latest updates starting at stable v1.16.0+ started to fail.

https://github.com/vulk/cncf_ci/issues/70#issuecomment-735838448

**Errors**
The first issue/error hit a snag when envoy updated their directory path to build_release from envoy/ to linux/$ARCH/
```
/builds/b57e3f29/0/envoyproxy/envoy
$ cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ .
cp: cannot stat '/envoy/envoy-50314/envoy/build_release/': No such file or directory
ERROR: Job failed: exit code 1
```

The next issue, the Dockerfile-envoy-alpine fails to ADD source files (despite them being present). For now, we'll disable the alpine Docker build until we can further debug the issues seen.
Also, Dockerfile-envoy-alpine-debug was removed entirely, so we have removed that build as well.

```
Step 5/10 : ARG ENVOY_BINARY_SUFFIX=_stripped
 ---> Using cache
 ---> 0218880157fe
Step 6/10 : ADD linux/amd64/build_release${ENVOY_BINARY_SUFFIX}/* /usr/local/bin/
ADD failed: no source files were specified
ERROR: Job failed: exit code 1
```