### PR TITLE
Update envoy stable to v1.16.1 on integration (dev.cncf.ci triggers)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,30 +36,37 @@ baseimage-arm:
     variables:
       - $ARCH == "arm64"
   script:
-    - cd ./ci/build_container/
-    - sed -i "1s|.*|FROM crosscloudci/ubuntu-bazel-arm64:disco|" ./Dockerfile-ubuntu
-    - sed -i -e '/wget -O - https:/s/^/#/' build_container_ubuntu.sh
-    - sed -i -e '/apt-add-repository "deb https:\/\/apt.llvm.org\/xenial\/ llvm-toolchain-xenial-8 main"/s/^/#/' build_container_ubuntu.sh
-    - sed -i -e '/add-apt-repository -y ppa:ubuntu-toolchain-r\/test/s/^/#/' build_container_ubuntu.sh
-    - sed -i -e '/echo/s/^/#/' build_container_ubuntu.sh
-    - sed -i -e '/curl https:\/\/bazel.build\/bazel-release.pub.gpg/s/^/#/' build_container_ubuntu.sh
-    - sed -i -e '/apt-get install -y bazel/s/^/#/' build_container_ubuntu.sh
-    - CIRCLE_SHA1="$CI_COMMIT_REF_SLUG.arm64" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" ./docker_build.sh
+    - git clone https://github.com/envoyproxy/envoy-build-tools.git
+    - cd envoy-build-tools/build_container
+    - sed -i "1s|.*|FROM crosscloudci/ubuntu-bazel-arm64:xenial|" ./Dockerfile-ubuntu
+    - sed -i "/arch=amd64/{n;n;s/.*/    \n\n\n\n/}" ./build_container_ubuntu.sh
+    - sed -i "/arch=amd64/{n;n;s/.*/    'aarch64' )/}" ./build_container_ubuntu.sh
+    - sed -i '/arch=amd64/{n;n;n;s/.*/        add-apt-repository "deb [arch=arm64] https:\/\/download.docker.com\/linux\/ubuntu $(lsb_release -cs) stable"/}' ./build_container_ubuntu.sh
+    - sed -i '/arch=amd64/{n;n;n;n;s/.*/        ;;/}' ./build_container_ubuntu.sh
+    - sed -i '/arch=amd64/{n;n;n;n;n;s/.*/esac/}' ./build_container_ubuntu.sh
+    - sed -i "/LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04/{n;n;n;s/.*/    \n\n\n\n /}" ./build_container_ubuntu.sh
+    - sed -i "/LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04/{n;n;n;s/.*/    'aarch64' )/}" ./build_container_ubuntu.sh
+    - sed -i "/LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04/{n;n;n;n;s/.*/        LLVM_DISTRO=aarch64-linux-gnu/}" ./build_container_ubuntu.sh
+    - sed -i "/LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04/{n;n;n;n;n;s/.*/        LLVM_SHA256SUM=f8f3e6bdd640079a140a7ada4eb6f5f05aeae125cf54b94d44f733b0e8691dc2/}" ./build_container_ubuntu.sh
+    - sed -i "/LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04/{n;n;n;n;n;n;s/.*/        ;;/}" ./build_container_ubuntu.sh
+    - sed -i "/LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04/{n;n;n;n;n;n;n;s/.*/esac/}" ./build_container_ubuntu.sh
+    - CONTAINER_TAG="$CI_COMMIT_REF_SLUG.arm64" IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" ./docker_build.sh
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker push "$CI_REGISTRY_IMAGE/envoy-build-ubuntu:$CI_COMMIT_REF_SLUG.arm64"
 
-    
 compile-arm:
   tags:
     - arm
-  image: "$CI_REGISTRY_IMAGE/envoy-build-ubuntu:$CI_COMMIT_REF_SLUG.arm64"
+  image: "crosscloudci/debian-docker:arm64"
   stage: build
   only:
     variables:
       - $ARCH == "arm64"
   script:
-    - ln -s $(pwd) /source
-    - BAZEL_BUILD_EXTRA_OPTIONS='--host_javabase=@local_jdk//:jdk' ./ci/do_ci.sh bazel.release.server_only
+    - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
+    - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
+    - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
+    - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
@@ -77,8 +84,6 @@ compile:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
-    - pwd
-    - ls -la
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,8 +75,8 @@ compile:
       - $ARCH == "amd64"
   script:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
-    - ln -s $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
-    - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
+    - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
+    - cd /envoy/envoy-"$CI_PIPELINE_ID"
     - pwd
     - ls -la
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,6 +101,7 @@ container-arm:
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine-debug
     - sed -i "1s|.*|FROM arm64v8/ubuntu:19.04|" ./ci/Dockerfile-envoy-image
+    - sleep 100000000
     - docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ compile:
   script:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - ln -s $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
-    - cd /envoy/envoy-"$CI_PIPELINE_ID"
+    - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - pwd
     - ls -la
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,12 +64,14 @@ compile-arm:
     - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
     - popd 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
     expire_in: 5 weeks
     paths:
       - ./build_release_stripped/envoy
+      - ./build_release/envoy
 
 compile:
   image: "crosscloudci/debian-docker:latest"
@@ -84,12 +86,14 @@ compile:
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
     - popd 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
     expire_in: 5 weeks
     paths:
      - ./build_release_stripped/envoy
+     - ./build_release/envoy
 
 container-arm:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,8 +60,10 @@ compile-arm:
   script:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
-    - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
+    - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
+    - popd 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
@@ -78,8 +80,10 @@ compile:
   script:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
-    - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
+    - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
+    - popd 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
@@ -101,7 +105,6 @@ container-arm:
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine
     - sed -i "1s|.*|FROM crosscloudci/alpine-glibc:arm64|" ./ci/Dockerfile-envoy-alpine-debug
     - sed -i "1s|.*|FROM arm64v8/ubuntu:19.04|" ./ci/Dockerfile-envoy-image
-    - sleep 100000000
     - docker build --pull -f ci/Dockerfile-envoy-image -t "$CI_REGISTRY_IMAGE:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine -t "$CI_REGISTRY_IMAGE/alpine:$IMAGE_TAG" .
     - docker build --pull -f ci/Dockerfile-envoy-alpine-debug -t "$CI_REGISTRY_IMAGE/alpine-debug:$IMAGE_TAG" .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,11 @@ compile:
     variables:
       - $ARCH == "amd64"
   script:
+    - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
+    - ln -s $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
+    - cd /envoy/envoy-"$CI_PIPELINE_ID"
     - pwd
+    - ls -la
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,12 +20,7 @@ before_script:
     else
       export CROSS_CLOUD_YML="$CROSS_CLOUD_YML"
     fi
-  - >
-    if [ "$CI_JOB_NAME" == "compile-arm" ]; then
-      source /opt/local/ubuntu/etc/rvmrc ; source /opt/local/ubuntu/etc/profile.d/rvm.sh ; rvm use ruby-2.4.0 ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; chmod +x ./bin/update_dashboard ; ./bin/update_dashboard ; popd
-    else
-      source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; chmod +x ./bin/update_dashboard ; ./bin/update_dashboard ; popd
-    fi
+  - source /opt/local/etc/rvmrc ; source /opt/local/etc/profile.d/rvm.sh ; cp -a --no-preserve=mode /opt/local/dashboard /dashboard ; pushd /dashboard ; source /opt/local/.env ; chmod +x ./bin/update_dashboard ; ./bin/update_dashboard ; popd
 
 baseimage-arm:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,15 +63,15 @@ compile-arm:
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
     - popd 
-    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
     expire_in: 5 weeks
     paths:
-      - ./build_release_stripped/envoy
       - ./build_release/envoy
+      - ./build_release_stripped/envoy
 
 compile:
   image: "crosscloudci/debian-docker:latest"
@@ -85,15 +85,15 @@ compile:
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
     - popd 
-    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
+    - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true
     expire_in: 5 weeks
     paths:
-     - ./build_release_stripped/envoy
      - ./build_release/envoy
+     - ./build_release_stripped/envoy
 
 container-arm:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ compile-arm:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
-    - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
+    - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
     - popd 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 
@@ -83,7 +83,7 @@ compile:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - pushd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
-    - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
+    - ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release.server_only'
     - popd 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release/ . 
     - cp -a /envoy/envoy-"$CI_PIPELINE_ID"/envoy/build_release_stripped/ . 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,6 @@ baseimage-arm:
     variables:
       - $ARCH == "arm64"
   script:
-    - sleep 1000000
     - cd ./ci/build_container/
     - sed -i "1s|.*|FROM crosscloudci/ubuntu-bazel-arm64:disco|" ./Dockerfile-ubuntu
     - sed -i -e '/wget -O - https:/s/^/#/' build_container_ubuntu.sh
@@ -75,6 +74,7 @@ compile:
     variables:
       - $ARCH == "amd64"
   script:
+    - pwd
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ compile-arm:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
     - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
-    - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
+    - IMAGE_NAME="$CI_REGISTRY_IMAGE/envoy-build-ubuntu" IMAGE_ID="$CI_COMMIT_REF_SLUG.arm64" ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ compile:
   script:
     - mkdir -p /envoy/envoy-"$CI_PIPELINE_ID"
     - cp -a $(pwd) /envoy/envoy-"$CI_PIPELINE_ID"
-    - cd /envoy/envoy-"$CI_PIPELINE_ID"
+    - cd /envoy/envoy-"$CI_PIPELINE_ID"/envoy
     - pwd
     - ls -la
     - ./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,7 +1,7 @@
 project:	
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/envoy/icon/color/envoy-icon-color.svg?sanitize=true"	
   display_name: Envoy
-  sub_title: Service Mesh
+  sub_title: Network Proxy
   project_url: "https://github.com/envoyproxy/envoy"
   arch:
     - "amd64"


### PR DESCRIPTION
## Description
  - v1.16.1 was released on 11/30/2020
  - update stable on integration
  - manually tested pipeline on dev.cncf.ci
  - this also includes gitlab-ci.yml fixes 

## Issues:

https://github.com/vulk/cncf_ci/issues/70

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x] Manually tested on cidev.cncf.ci
 - [x] Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [ ]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
